### PR TITLE
fix: add uptime fallback mechanism

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use the official Python image from the Docker Hub
-FROM python:3.9-slim
+FROM python:3.14.2-slim
 
 # Set the working directory inside the container
 WORKDIR /app


### PR DESCRIPTION
This PR introduces caching for validator uptime values to improve reliability. This prevents displaying "N/A". 

The caching mechanism ensures that if the latest uptime value is unavailable, the system falls back to the last known value. The starting value for each node (when no data is yet retrieved from the API) is `0.0`, and the cache is updated on every successful fetch.

Also updates the Python Docker base image.

Relates to this [Notion task](https://www.notion.so/senseinodes/Corregir-campo-de-Uptime-en-https-avax-dashboard-senseinode-com-2df8f16a6aad80b9a778e25cd62d2725?)