### PR TITLE
fix: refactor location retrieval

### DIFF
--- a/web/app.py
+++ b/web/app.py
@@ -1,5 +1,6 @@
 from flask import Flask, render_template, jsonify
 import requests
+import pycountry
 
 app = Flask(__name__)
 
@@ -31,15 +32,15 @@ def fetch_uptime():
         uptime_data = {}
         for item in data.get("items", []):
             node_id = item.get("nodeId")
-            avg_uptime = item.get("node", {}).get("uptime", {}).get("avg", "N/A")
+            node_info = item.get("node", {})
             name = item.get("name", "⚠️ Unknown")
-            location_city = (
-                item.get("node", {}).get("location", {}).get("city", "Unknown")
-            )
-            location_country = (
-                item.get("node", {}).get("location", {}).get("country", "Unknown")
-            )
-            location = f"{location_city}, {location_country}"
+            
+            avg_uptime = node_info.get("uptime", {}).get("avg", "N/A")
+            location_data = node_info.get("location", {})
+            location_city = location_data.get("city", "")
+            location_country = location_data.get("country", "")
+            node_ip = node_info.get("ip", "")
+            
             stake_from_self = item.get("stake", {}).get("fromSelf", "N/A")
             stake_from_delegations = item.get("stake", {}).get("fromDelegations", "N/A")
 
@@ -63,6 +64,31 @@ def fetch_uptime():
                 else "N/A"
             )
 
+            # Determine location: use API data or fallback to IP geolocation
+            if location_city and location_country:
+                location = f"{location_city}, {location_country}"
+            elif node_ip:
+                try:
+                    ip_info_response = requests.get(
+                        f"https://ipinfo.io/{node_ip}/json",
+                        timeout=5
+                    )
+                    ip_info_data = ip_info_response.json()
+                    city = ip_info_data.get("city", "Unknown")
+                    country_code = ip_info_data.get("country", "Unknown")
+                    if country_code != "Unknown":
+                        try:
+                            country = pycountry.countries.get(alpha_2=country_code).name
+                        except (AttributeError, KeyError):
+                            country = country_code
+                    else:
+                        country = "Unknown"
+                    location = f"{city}, {country}"
+                except Exception:
+                    location = "Unknown, Unknown"
+            else:
+                location = "Unknown, Unknown"
+
             if node_id:
                 uptime_data[node_id] = {
                     "uptime": formatted_uptime,
@@ -71,52 +97,6 @@ def fetch_uptime():
                     "stake_from_self": formatted_stake_from_self,
                     "stake_from_delegations": formatted_stake_from_delegations,
                 }
-
-            # Handling for validators that not return locations
-            if node_id == "NodeID-2Coj79FAu7rPdSdYdJ27CqTr1K2p45gze":
-                if uptime_data[node_id]["location"] == "Unknown, Unknown":
-                    ip_info_response = requests.get(
-                        "https://ipinfo.io/158.255.76.58/json"
-                    )
-                    ip_info_data = ip_info_response.json()
-                    city = ip_info_data.get("city", "Unknown")
-                    country = "Nigeria"  # Hardcode Nigeria (API doesn't support)
-                    uptime_data[node_id]["location"] = f"{city}, {country}"
-
-            elif node_id == "NodeID-9Efcx2E5uEHZqZSTWT1jPd8DfEkJaZeGj":
-                if uptime_data[node_id]["location"] == "Unknown, Unknown":
-                    ip_info_response = requests.get(
-                        "https://ipinfo.io/160.202.130.67/json"
-                    )
-                    ip_info_data = ip_info_response.json()
-                    city = ip_info_data.get("city", "Unknown")
-                    country = "Brasil"  # Hardcode Brasil (API doesn't support)
-                    uptime_data[node_id]["location"] = f"{city}, {country}"
-
-            elif node_id == "NodeID-8mirL2rorHYSEbkBxu8TwodvpN29RrNY3":
-                if uptime_data[node_id]["location"] == "Unknown, Unknown":
-                    ip_info_response = requests.get(
-                        "https://ipinfo.io/103.88.234.47/json"
-                    )
-                    ip_info_data = ip_info_response.json()
-                    city = ip_info_data.get("city", "Unknown")
-                    country = "Mexico"  # Hardcode Mexico (API doesn't support)
-                    uptime_data[node_id]["location"] = f"{city}, {country}"
-
-            elif node_id == "NodeID-F3SZA2ZNdRjTBe3GYyRQFDaCXB3DyaZQQ":
-                if uptime_data[node_id]["location"]:
-                    ip_info_response = requests.get(
-                        "https://ipinfo.io/160.202.130.45/json"
-                    )
-                    ip_info_data = ip_info_response.json()
-                    city = ip_info_data.get("city", "Unknown")
-                    country = "Brasil"  # Hardcode Brasil again (API doesn't support)
-                    # Hardcode specified values
-                    if city != "Unknown":
-                        city = "São Paulo"
-                    if country != "Unknown":
-                        country = "Brasil"
-                    uptime_data[node_id]["location"] = f"{city}, {country}"
 
         return uptime_data
 

--- a/web/app.py
+++ b/web/app.py
@@ -33,7 +33,6 @@ def fetch_uptime():
         for item in data.get("items", []):
             node_id = item.get("nodeId")
             node_info = item.get("node", {})
-            name = item.get("name", "⚠️ Unknown")
             
             avg_uptime = node_info.get("uptime", {}).get("avg", "N/A")
             location_data = node_info.get("location", {})
@@ -92,7 +91,6 @@ def fetch_uptime():
             if node_id:
                 uptime_data[node_id] = {
                     "uptime": formatted_uptime,
-                    "name": name,
                     "location": location,
                     "stake_from_self": formatted_stake_from_self,
                     "stake_from_delegations": formatted_stake_from_delegations,

--- a/web/app.py
+++ b/web/app.py
@@ -1,6 +1,7 @@
-from flask import Flask, render_template, jsonify
-import requests
 import pycountry
+import requests
+
+from flask import Flask, render_template, jsonify
 
 app = Flask(__name__)
 

--- a/web/requirements.txt
+++ b/web/requirements.txt
@@ -1,2 +1,3 @@
 Flask==2.2.5
+pycountry==23.12.11
 requests==2.31.0

--- a/web/templates/dashboard.html
+++ b/web/templates/dashboard.html
@@ -65,14 +65,9 @@
             padding: 12px 15px;
             font-weight: bold;
         }
-        .validator-name {
+        .validator-id {
             font-size: 13.5px;
             margin: 0;
-        }
-        .validator-id {
-            font-size: 12px;
-            margin: 5px 0 0 0;
-            opacity: 0.8;
         }
         .validator-body {
             padding: 15px;
@@ -208,7 +203,7 @@
                             content += `
                                 <div class='validator'>
                                     <div class='validator-header'>
-                                        <p class='validator-name'>Node ID: ${nodeId}</p>
+                                        <p class='validator-id'>Node ID: ${nodeId}</p>
                                     </div>
                                     <div class='validator-body'>
                                         <div class='validator-detail'>
@@ -227,7 +222,7 @@
                         content += `
                             <div class='validator'>
                                 <div class='validator-header'>
-                                    <p class='validator-name'>${nodeId}</p>
+                                    <p class='validator-id'>${nodeId}</p>
                                 </div>
                                 <div class='validator-body'>
                                     <div class='validator-detail'>
@@ -285,7 +280,7 @@
                             fallbackContent += `
                                 <div class='validator'>
                                     <div class='validator-header'>
-                                        <p class='validator-name'>${nodeId} (SAMPLE DATA)</p>
+                                        <p class='validator-id'>${nodeId} (SAMPLE DATA)</p>
                                     </div>
                                     <div class='validator-body'>
                                         <div class='validator-detail'>


### PR DESCRIPTION
This PR refactors how validator location information is fetched with a better fallback logic. The main improvement is a more robust and consistent approach to determining the locations when not provided by the API, replacing ad-hoc hardcoded logic with a dynamic IP-based geolocation lookup and standardized country names.

Additionally, an unused variable and CSS style are removed.

Relates to this [Notion task](https://www.notion.so/senseinodes/Corregir-campo-Location-2e18f16a6aad80b19c0bfb90bd93806b?source=copy_link)