### PR TITLE
feat: add expiration date

### DIFF
--- a/web/app.py
+++ b/web/app.py
@@ -1,6 +1,7 @@
 import pycountry
 import requests
 
+from datetime import datetime
 from flask import Flask, render_template, jsonify
 
 app = Flask(__name__)
@@ -34,18 +35,17 @@ def fetch_uptime():
         for item in data.get("items", []):
             node_id = item.get("nodeId")
             node_info = item.get("node", {})
-            
-            avg_uptime = node_info.get("uptime", {}).get("avg", "N/A")
             location_data = node_info.get("location", {})
             location_city = location_data.get("city", "")
             location_country = location_data.get("country", "")
             node_ip = node_info.get("ip", "")
-            
-            stake_from_self = item.get("stake", {}).get("fromSelf", "N/A")
-            stake_from_delegations = item.get("stake", {}).get("fromDelegations", "N/A")
+            avg_uptime = node_info.get("uptime", {}).get("avg", "Unknown")
+            end_time = item.get("endTime", "Unknown")
+            stake_from_self = item.get("stake", {}).get("fromSelf", "Unknown")
+            stake_from_delegations = item.get("stake", {}).get("fromDelegations", "Unknown")
 
             # Processing values to avoid errors in conversions
-            # Use cached value if `avg_uptime` is N/A, otherwise update cache
+            # Use cached value if `avg_uptime` is unknown, otherwise update cache
             if isinstance(avg_uptime, (int, float)):
                 formatted_uptime = round(avg_uptime * 100, 2)
                 if node_id:
@@ -56,12 +56,12 @@ def fetch_uptime():
             formatted_stake_from_self = (
                 round(int(stake_from_self) / 1_000_000_000, 2)
                 if stake_from_self
-                else "N/A"
+                else "Unknown"
             )
             formatted_stake_from_delegations = (
                 round(int(stake_from_delegations) / 1_000_000_000, 2)
                 if stake_from_delegations
-                else "N/A"
+                else "Unknown"
             )
 
             # Determine location: use API data or fallback to IP geolocation
@@ -89,10 +89,21 @@ def fetch_uptime():
             else:
                 location = "Unknown, Unknown"
 
+            # Format expiration date
+            if end_time != "Unknown":
+                try:
+                    dt = datetime.fromisoformat(end_time.replace('Z', '+00:00'))
+                    formatted_end_time = dt.strftime("%b %d, %Y at %H:%M UTC")
+                except Exception:
+                    formatted_end_time = "Unknown"
+            else:
+                formatted_end_time = "Unknown"
+
             if node_id:
                 uptime_data[node_id] = {
-                    "uptime": formatted_uptime,
                     "location": location,
+                    "uptime": formatted_uptime,
+                    "expiration_date": formatted_end_time,
                     "stake_from_self": formatted_stake_from_self,
                     "stake_from_delegations": formatted_stake_from_delegations,
                 }

--- a/web/app.py
+++ b/web/app.py
@@ -93,7 +93,7 @@ def fetch_uptime():
             if end_time != "Unknown":
                 try:
                     dt = datetime.fromisoformat(end_time.replace('Z', '+00:00'))
-                    formatted_end_time = dt.strftime("%b %d, %Y at %H:%M UTC")
+                    formatted_end_time = dt.strftime("%b %d, %Y %H:%M UTC")
                 except Exception:
                     formatted_end_time = "Unknown"
             else:

--- a/web/app.py
+++ b/web/app.py
@@ -12,6 +12,8 @@ VALIDATORS = [
     "NodeID-2Coj79FAu7rPdSdYdJ27CqTr1K2p45gze",  # Sensei 2
     "NodeID-9Efcx2E5uEHZqZSTWT1jPd8DfEkJaZeGj",  # Sensei 3
     "NodeID-8mirL2rorHYSEbkBxu8TwodvpN29RrNY3",  # Sensei 4
+    "NodeID-3f36M2b7dsAQXELyNeAhcGU5LsV86fNGC",
+    "NodeID-LRMPTwN2c9PQDeYNJaTpJHbLLQbXauwBs",
 ]
 
 # Construct API Endpoint dynamically

--- a/web/templates/dashboard.html
+++ b/web/templates/dashboard.html
@@ -234,6 +234,10 @@
                                         <span class='${getUptimeClass(details.uptime)}'>${details.uptime}%</span>
                                     </div>
                                     <div class='validator-detail'>
+                                        <span class='detail-label'>Expiration Date:</span>
+                                        <span>${details.expiration_date || 'Unknown'}</span>
+                                    </div>
+                                    <div class='validator-detail'>
                                         <span class='detail-label'>Stake from Self:</span>
                                         <span>${formatNumber(selfStake)} AVAX</span>
                                     </div>


### PR DESCRIPTION
Comes after #3.

This PR adds support for displaying each validator's expiration date and standardizing the representation of unknown data fields.

**Backend data processing improvements**

* Added API extraction and formatting of the validator's `endTime` field as a human-readable expiration date, handling ISO format conversion and defaulting to `"Unknown"` if not available. 
* Standardized the handling of unknown or missing data by replacing `"N/A"` with `"Unknown"` for fields such as `uptime`, `stake_from_self`, and `stake_from_delegations`.

**Local dashboard run**

<img width="1239" height="676" alt="image" src="https://github.com/user-attachments/assets/c7b27897-5243-4125-b0bd-2dad6cdf96d8" />

Relates to this [Notion task](https://www.notion.so/senseinodes/Agregar-campo-Expiration-Date-2e28f16a6aad80fab39dd95d22cff8c1?)