### PR TITLE
feat: add flags and explorer links

### DIFF
--- a/web/templates/dashboard.html
+++ b/web/templates/dashboard.html
@@ -69,6 +69,13 @@
             font-size: 13.5px;
             margin: 0;
         }
+        .validator-id a {
+            color: white;
+            text-decoration: none;
+        }
+        .validator-id a:hover {
+            text-decoration: underline;
+        }
         .validator-body {
             padding: 15px;
         }
@@ -203,7 +210,7 @@
                             content += `
                                 <div class='validator'>
                                     <div class='validator-header'>
-                                        <p class='validator-id'>Node ID: ${nodeId}</p>
+                                        <p class='validator-id'><a href='https://avascan.info/staking/validator/${nodeId}' target='_blank'>${nodeId}</a></p>
                                     </div>
                                     <div class='validator-body'>
                                         <div class='validator-detail'>
@@ -222,7 +229,7 @@
                         content += `
                             <div class='validator'>
                                 <div class='validator-header'>
-                                    <p class='validator-id'>${nodeId}</p>
+                                    <p class='validator-id'><a href='https://avascan.info/staking/validator/${nodeId}' target='_blank'>${nodeId}</a></p>
                                 </div>
                                 <div class='validator-body'>
                                     <div class='validator-detail'>
@@ -284,7 +291,7 @@
                             fallbackContent += `
                                 <div class='validator'>
                                     <div class='validator-header'>
-                                        <p class='validator-id'>${nodeId} (SAMPLE DATA)</p>
+                                        <p class='validator-id'><a href='https://avascan.info/staking/validator/${nodeId}' target='_blank'>${nodeId}</a> (SAMPLE DATA)</p>
                                     </div>
                                     <div class='validator-body'>
                                         <div class='validator-detail'>


### PR DESCRIPTION
This PR adds country flag emojis to the display of validator locations and makes node IDs clickable links to their details on Avascan. 

**Local dashboard run**

<img width="1470" height="706" alt="image" src="https://github.com/user-attachments/assets/d7841b7b-ebcb-4818-ae0f-70ef1c0585af" />

Relates to [Notion task 1](https://www.notion.so/senseinodes/Agregar-banderas-de-pa-ses-2e38f16a6aad80f6a8ccdf821e4c58bd?source=copy_link) and [Notion task 2](https://www.notion.so/senseinodes/Agregar-links-al-explorer-por-cada-nodo-2e38f16a6aad8096a9d0eb79fc461058?source=copy_link)