### PR TITLE
fix: uptime cache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,4 +11,4 @@ COPY . .
 USER appuser
 
 EXPOSE 5000
-CMD ["gunicorn", "--bind", "0.0.0.0:5000", "--workers", "4", "--timeout", "120", "app:app"]
+CMD ["gunicorn", "--bind", "0.0.0.0:5000", "--workers", "1", "--timeout", "120", "app:app"]


### PR DESCRIPTION
This PR makes a minor change by reducing the number of Gunicorn worker processes to 1. This adjustment is intended to address issues related to concurrency (each worker having its own cache) and reduce unnecessary resource usage.

Relates to this [Notion task](https://www.notion.so/senseinodes/Hacer-el-deploy-2e68f16a6aad8027bd1cc5b457f4f6bc?source=copy_link)