### PR TITLE
fix: update Avascan API URL

### DIFF
--- a/app.py
+++ b/app.py
@@ -13,7 +13,7 @@ VALIDATORS = config['validators']
 REFRESH_INTERVAL_MINUTES = config['refresh_interval_minutes']
 REFRESH_INTERVAL_MS = REFRESH_INTERVAL_MINUTES * 60 * 1000
 API_ENDPOINT = (
-    "https://api.avascan.info/v2/network/mainnet/staking/validations?nodeIds="
+    "https://api.routescan.io/v2/network/mainnet/staking/validations?nodeIds="
     + ",".join(VALIDATORS)
     + "&status=active"
 )

--- a/static/dashboard.js
+++ b/static/dashboard.js
@@ -53,24 +53,16 @@ function fetchData() {
                 return;
             }
             
+            // Check if backend returned an error string instead of validator data
+            const firstNodeId = Object.keys(data)[0];
+            if (typeof data[firstNodeId] === 'string') {
+                showError("API Error: Unable to fetch latest validator data.");
+                setLoading(false);
+                return;
+            }
+            
             Object.keys(data).forEach(function(nodeId) {
                 let details = data[nodeId];
-                
-                // Handle case where details might be a string
-                if (typeof details === 'string') {
-                    content += `
-                        <div class='validator'>
-                            <div class='validator-header'>
-                                <p class='validator-id'><a href='https://avascan.info/staking/validator/${nodeId}' target='_blank'>${nodeId}</a></p>
-                            </div>
-                            <div class='validator-body'>
-                                <div class='validator-detail'>
-                                    <span>Status: ${details}</span>
-                                </div>
-                            </div>
-                        </div>`;
-                    return;
-                }
                 
                 // Calculate total stake - ensure values are numbers
                 const selfStake = parseFloat(details.stake_from_self) || 0;


### PR DESCRIPTION
This pull request updates the dashboard to use the new Avascan API endpoint and improves error handling in the frontend when fetching validator data. The changes are:

**API Endpoint Update**

* Changed the staking validator API endpoint in `app.py` from `avascan.info` to `routescan.io` to ensure continued data availability.

**Frontend Error Handling**

* Updated `fetchData()` in `static/dashboard.js` to detect and handle cases where the backend returns an error string instead of validator data, displaying a clear error message to users.