### PR TITLE
feat: expose Avascan API errors

### DIFF
--- a/app.py
+++ b/app.py
@@ -156,19 +156,15 @@ def fetch_validator_data():
 
 def fetch_uptime():
     """Fetch and format validator uptime data."""
-    try:
-        data = fetch_validator_data()
-        uptime_data = {}
-        
-        for item in data.get("items", []):
-            node_id, formatted_data = parse_validator_item(item)
-            if node_id and formatted_data:
-                uptime_data[node_id] = formatted_data
-        
-        return uptime_data
+    data = fetch_validator_data()
+    uptime_data = {}
     
-    except Exception as e:
-        return {validator: f"Error {e}" for validator in VALIDATORS}
+    for item in data.get("items", []):
+        node_id, formatted_data = parse_validator_item(item)
+        if node_id and formatted_data:
+            uptime_data[node_id] = formatted_data
+    
+    return uptime_data
 
 
 @app.route("/")

--- a/static/dashboard.js
+++ b/static/dashboard.js
@@ -100,65 +100,6 @@ function fetchData() {
         error: function(xhr, status, error) {
             console.error("Error details:", xhr, status, error);
             showError("API Error: Unable to fetch latest validator data.");
-            
-            // If we have no data yet, show sample data as fallback
-            if ($("#validators").children().length === 0) {
-                const fallbackData = {
-                    "NodeID-F3SZA2ZNdRjTBe3GYyRQFDaCXB3DyaZQQ": {
-                        "name": "Sample Validator 1",
-                        "location": "New York, USA",
-                        "uptime": 99.8,
-                        "stake_from_self": 2000,
-                        "stake_from_delegations": 5000
-                    },
-                    "NodeID-C6MR4QwFVyf7vxttwLFbxopJrD5ce4Mwv": {
-                        "name": "Sample Validator 2",
-                        "location": "London, UK",
-                        "uptime": 98.5,
-                        "stake_from_self": 1500,
-                        "stake_from_delegations": 3500
-                    }
-                };
-                
-                let fallbackContent = "";
-                Object.keys(fallbackData).forEach(function(nodeId) {
-                    let details = fallbackData[nodeId];
-                    fallbackContent += `
-                        <div class='validator'>
-                            <div class='validator-header'>
-                                <p class='validator-id'><a href='https://avascan.info/staking/validator/${nodeId}' target='_blank'>${nodeId}</a> (SAMPLE DATA)</p>
-                            </div>
-                            <div class='validator-body'>
-                                <div class='validator-detail'>
-                                    <span class='detail-label'>Location:</span>
-                                    <span>${details.location}</span>
-                                </div>
-                                <div class='validator-detail'>
-                                    <span class='detail-label'>Uptime:</span>
-                                    <span class='${getUptimeClass(details.uptime)}'>${details.uptime}%</span>
-                                </div>
-                                <div class='validator-detail'>
-                                    <span class='detail-label'>Stake from Self:</span>
-                                    <span>${formatNumber(details.stake_from_self)} AVAX</span>
-                                </div>
-                                <div class='validator-detail'>
-                                    <span class='detail-label'>Stake from Delegations:</span>
-                                    <span>${formatNumber(details.stake_from_delegations)} AVAX</span>
-                                </div>
-                                <div class='validator-detail total-stake'>
-                                    <span class='detail-label'>Total Stake:</span>
-                                    <span>${formatNumber(details.stake_from_self + details.stake_from_delegations)} AVAX</span>
-                                </div>
-                            </div>
-                        </div>`;
-                });
-                
-                $("#validators").html(fallbackContent);
-                $("#error-container").append(
-                    "<div class='error-message' style='background-color: #fff3cd; color: #856404;'>" +
-                    "Showing sample data. The actual data could not be loaded.</div>"
-                );
-            }
         },
         complete: function() {
             setLoading(false);

--- a/static/dashboard.js
+++ b/static/dashboard.js
@@ -53,14 +53,6 @@ function fetchData() {
                 return;
             }
             
-            // Check if backend returned an error string instead of validator data
-            const firstNodeId = Object.keys(data)[0];
-            if (typeof data[firstNodeId] === 'string') {
-                showError("API Error: Unable to fetch latest validator data.");
-                setLoading(false);
-                return;
-            }
-            
             Object.keys(data).forEach(function(nodeId) {
                 let details = data[nodeId];
                 
@@ -107,7 +99,7 @@ function fetchData() {
         },
         error: function(xhr, status, error) {
             console.error("Error details:", xhr, status, error);
-            showError("Failed to fetch validator data. Please try again.");
+            showError("API Error: Unable to fetch latest validator data.");
             
             // If we have no data yet, show sample data as fallback
             if ($("#validators").children().length === 0) {


### PR DESCRIPTION
This pull request simplifies error handling in both the backend (`app.py`) and frontend (`dashboard.js`) for fetching validator data. The main changes remove fallback logic and redundant error checks, streamlining how errors are reported to users.

**Backend error handling simplification**
- Removed the `try/except` block from `fetch_uptime()` in `app.py`, so errors are no longer caught and returned as error strings in the API response. 

**Frontend error handling and fallback removal**
- Removed logic in `dashboard.js` that checked for error strings in the API response and showed a specific error message if present.
- Eliminated the fallback mechanism that displayed sample validator data when the API call failed; now, only an error message is shown on failure. 