### PR TITLE
fix: implement location cache and change geolocation provider

### DIFF
--- a/app.py
+++ b/app.py
@@ -29,6 +29,8 @@ app = Flask(__name__)
 uptime_cache = {validator: 0.0 for validator in VALIDATORS}
 # Cache for last known IP addresses
 ip_cache = {}
+# Cache for IP to location data
+location_cache = {}
 
 
 def country_code_to_flag(country_code):
@@ -48,7 +50,10 @@ def get_country_code_from_name(country_name):
 
 
 def get_location_from_ip(node_ip):
-    """Fetch location data using IP geolocation service."""
+    """Fetch location data if not already cached using IP geolocation service."""
+    if node_ip in location_cache:
+        return location_cache[node_ip]
+
     try:
         ip_info_response = requests.get(
             f"https://ipinfo.io/{node_ip}/json",
@@ -67,7 +72,9 @@ def get_location_from_ip(node_ip):
             country = "Unknown"
             country_code = ""
         
-        return f"{city}, {country}", country_code
+        result = f"{city}, {country}", country_code
+        location_cache[node_ip] = result
+        return result
     except Exception:
         return "Unknown, Unknown", ""
 

--- a/app.py
+++ b/app.py
@@ -56,12 +56,12 @@ def get_location_from_ip(node_ip):
 
     try:
         ip_info_response = requests.get(
-            f"https://ipinfo.io/{node_ip}/json",
+            f"http://ip-api.com/json/{node_ip}",
             timeout=IP_GEOLOCATION_TIMEOUT_SECONDS
         )
         ip_info_data = ip_info_response.json()
         city = ip_info_data.get("city", "Unknown")
-        country_code = ip_info_data.get("country", "Unknown")
+        country_code = ip_info_data.get("countryCode", "Unknown")
         
         if country_code != "Unknown":
             try:


### PR DESCRIPTION
Relates to this [Notion card](https://www.notion.so/senseinodes/Fix-Location-fields-in-Avax-dashboard-35f8f16a6aad8074b5fed0a9b9d4b50c?source=copy_link)

### Motivation
The dashboard periodically refreshes, making multiple separate requests to the IP geolocation API each time to resolve validator IPs to their physical locations. The previous provider (`ipinfo.io`) heavily rate-limits unauthenticated API requests, especially those originating from datacenter IPs (like OVH, AWS, DigitalOcean). This caused the dashboard to immediately fail and fall back to displaying "Unknown, Unknown" for validator locations.

### Changes
1. **Implemented Location Caching**: Introduced an in-memory `location_cache` dictionary. Before querying the geolocation service, the app checks if the location string for a given IP is already cached. If it is a new IP, it queries the service once, caches the formatted location result, and returns it. This significantly reduces requests.
2. **Switched Geolocation Provider**: Switched the IP geolocation backend to `ip-api.com`. `ip-api.com` allows 45 HTTP requests per minute without authentication, does not aggressively block datacenter IPs via Cloudflare, and provides the necessary city and country information required for the dashboard. This works in tandem with our in-memory cache to guarantee extreme reliability.