### PR TITLE
Fix: Switch geolocation provider to freeipapi.com

### DIFF
--- a/app.py
+++ b/app.py
@@ -29,6 +29,8 @@ app = Flask(__name__)
 uptime_cache = {validator: 0.0 for validator in VALIDATORS}
 # Cache for last known IP addresses
 ip_cache = {}
+# Cache for IP to location data
+location_cache = {}
 
 
 def country_code_to_flag(country_code):
@@ -48,7 +50,10 @@ def get_country_code_from_name(country_name):
 
 
 def get_location_from_ip(node_ip):
-    """Fetch location data using IP geolocation service."""
+    """Fetch location data if not already cached using IP geolocation service."""
+    if node_ip in location_cache:
+        return location_cache[node_ip]
+
     try:
         ip_info_response = requests.get(
             f"https://ipinfo.io/{node_ip}/json",
@@ -67,7 +72,9 @@ def get_location_from_ip(node_ip):
             country = "Unknown"
             country_code = ""
         
-        return f"{city}, {country}", country_code
+        result = f"{city}, {country}", country_code
+        location_cache[node_ip] = result
+        return result
     except Exception:
         return "Unknown, Unknown", ""
 

--- a/app.py
+++ b/app.py
@@ -56,12 +56,12 @@ def get_location_from_ip(node_ip):
 
     try:
         ip_info_response = requests.get(
-            f"https://ipinfo.io/{node_ip}/json",
+            f"https://freeipapi.com/api/json/{node_ip}",
             timeout=IP_GEOLOCATION_TIMEOUT_SECONDS
         )
         ip_info_data = ip_info_response.json()
-        city = ip_info_data.get("city", "Unknown")
-        country_code = ip_info_data.get("country", "Unknown")
+        city = ip_info_data.get("cityName", "Unknown")
+        country_code = ip_info_data.get("countryCode", "Unknown")
         
         if country_code != "Unknown":
             try:


### PR DESCRIPTION
### Motivation
The previous IP geolocation provider (`ipinfo.io`) heavily rate-limits unauthenticated API requests originating from datacenter IPs (like OVH, AWS, DigitalOcean). This caused the dashboard running on our VPS to immediately fail and fall back to displaying "Unknown, Unknown" for all validator locations.

### Changes
Switched the IP geolocation backend from `ipinfo.io` to `freeipapi.com`. `freeipapi.com` allows 60 requests per minute without authentication, does not aggressively block datacenter IPs, and provides the necessary city and country information required for the dashboard. This works in tandem with our in-memory cache to guarantee extreme reliability.